### PR TITLE
fix TrackerOverviewScreen check mealType

### DIFF
--- a/tracker/tracker_presentation/src/main/java/com/plcoding/tracker_presentation/tracker_overview/TrackerOverviewScreen.kt
+++ b/tracker/tracker_presentation/src/main/java/com/plcoding/tracker_presentation/tracker_overview/TrackerOverviewScreen.kt
@@ -59,15 +59,17 @@ fun TrackerOverviewScreen(
                             .padding(horizontal = spacing.spaceSmall)
                     ) {
                         state.trackedFoods.forEach { food ->
-                            TrackedFoodItem(
-                                trackedFood = food,
-                                onDeleteClick = {
-                                    viewModel.onEvent(
-                                        TrackerOverviewEvent
-                                            .OnDeleteTrackedFoodClick(food)
-                                    )
-                                }
-                            )
+                            if(meal.mealType == food.mealType) {
+                                TrackedFoodItem(
+                                    trackedFood = food,
+                                    onDeleteClick = {
+                                        viewModel.onEvent(
+                                            TrackerOverviewEvent
+                                                .OnDeleteTrackedFoodClick(food)
+                                        )
+                                    }
+                                )
+                            }
                             Spacer(modifier = Modifier.height(spacing.spaceMedium))
                         }
                         AddButton(


### PR DESCRIPTION
There is a small problem with "TrackerOverviewScreen".
If you add food to breakfast, the food at breakfast is also shown at lunch, dinner, snack.
This can be solved by checking the mealType of TrackerOverviewScreen.
Also, Thank you for good lecture.