### PR TITLE
Bug Fix - Meals defaulting to Breakfast list

### DIFF
--- a/tracker/tracker_domain/src/main/java/com/plcoding/tracker_domain/model/MealType.kt
+++ b/tracker/tracker_domain/src/main/java/com/plcoding/tracker_domain/model/MealType.kt
@@ -1,18 +1,18 @@
 package com.plcoding.tracker_domain.model
 
 sealed class MealType(val name: String) {
-    object Breakfast: MealType("breakfast")
-    object Lunch: MealType("lunch")
-    object Dinner: MealType("dinner")
-    object Snack: MealType("snack")
+    object Breakfast: MealType("Breakfast")
+    object Lunch: MealType("Lunch")
+    object Dinner: MealType("Dinner")
+    object Snack: MealType("Snacks")
 
     companion object {
         fun fromString(name: String): MealType {
             return when(name) {
-                "breakfast" -> Breakfast
-                "lunch" -> Lunch
-                "dinner" -> Dinner
-                "snack" -> Snack
+                "Breakfast" -> Breakfast
+                "Lunch" -> Lunch
+                "Dinner" -> Dinner
+                "Snacks" -> Snack
                 else -> Breakfast
             }
         }


### PR DESCRIPTION
on `TrackerOverviewScreen.kt`

When adding a meal with AddButton onClick, when passing context  to meal.name.asString(context), we are passing "Breakfast" or "Lunch" etc.

The sealed class MealType has all the object's name hardcoded with lowercase, same for the when cases, defaulting in the else case all the time, adding all the meals to the breakfast list.

Similar with Snacks as context vs snack as default name.

